### PR TITLE
[WIP] refresh app correctly when user logout from mm

### DIFF
--- a/packages/frontend/src/App.js
+++ b/packages/frontend/src/App.js
@@ -120,11 +120,12 @@ const App = () => {
         query: IS_LOGGED_IN,
       });
 
+      setRestored(true);
+
       // make sure logged in metamask user is the one that's saved to storage
       if (loggedInUser && client) {
         await initWeb3(client, loggedInUser);
       }
-      setRestored(true);
     }
     init();
   }, []);


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->

The bug was caused by `restored` variable, in `App.js`, since i logged in for the first time in rosebud, it always `await` the initialization of web3, and the `restored` variable will be false until i log in via Metamask. I moved the `setRestored(true)` above web3 initialization, in this way the page loads correctly before the web3 init.
But maybe it is not the solution that you are thinking about. For instance the `loggedInUser` variable could be set to false when someone logged out from Metamask. let me know.
Thanks in advance.

##### Checklist

- [X] Refresh the page correctly even if a user logged out to Metamask.

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
I have tested it on chrome in mac os.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #30 